### PR TITLE
Change Java default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Place this action step before Gradle tasks.
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: yumemi-inc/setup-java-gradle@v2
+- uses: yumemi-inc/setup-java-gradle@v3
 - run: ./gradlew ...
 ```
 
-By default, the Java version set up is `17`.
+By default, the Java version set up is `21`.
 Because it is the mainstream in current Android application development.
 If you want to change the version, specify it with `java-version` input.
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         # with: 
         #   ref: .. # specify if there is a branch other than the default branch where the code is frequently updated
-      - uses: yumemi-inc/setup-java-gradle@v2
+      - uses: yumemi-inc/setup-java-gradle@v3
         with:
           cache-read-only: false
           gradle-home-cache-cleanup: true

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   java-version:
     description: "Java version to use."
     required: false
-    default: "17"
+    default: "21"
   java-distribution: # original name is 'distribution'
     description: "Java distribution to use."
     required: false


### PR DESCRIPTION
This pull request updates the Java version and the Gradle setup action version in the project configuration files. The most important changes include updating the default Java version from 17 to 21 and changing the Gradle setup action from version 2 to version 3.

Updates to Java version:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R31): Changed the default Java version from 17 to 21.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L11-R11): Updated the default Java version from 17 to 21 in the `inputs` section.

Updates to Gradle setup action:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R31): Updated the Gradle setup action from `yumemi-inc/setup-java-gradle@v2` to `yumemi-inc/setup-java-gradle@v3`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R57)