### PR TITLE
Bump Java and Gradle actions to v5 for Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,12 +37,12 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
       with:
         cache-disabled: ${{ inputs.cache-disabled }}
         cache-read-only: ${{ inputs.cache-read-only }}


### PR DESCRIPTION
This PR updates the GitHub Actions used in this action:
 
- `actions/setup-java` from v4 to v5
- `gradle/actions/setup-gradle` from v4 to v5

These updates address the Node.js 20 deprecation warning and align the action with the latest supported Node.js runtime.

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/setup-java@v4, gradle/actions/setup-gradle@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Note
`gradle/actions` v6 is available, but it includes additional significant changes.
To keep this PR focused on fixing the Node.js deprecation warning, upgrading to v6 is considered out of scope and can be handled in a separate PR.