### PR TITLE
Use android/nowinandroid for sample project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out samlpe project 
         uses: actions/checkout@v4
         with:
-          repository: yumemi-inc/Tart
+          repository: android/nowinandroid
           path: sample
       - name: Build samlpe project for check
-        run: cd sample && ./gradlew assembleDebug
+        run: cd sample && ./gradlew :app:assembleDemoDebug


### PR DESCRIPTION
yumemi-inc/Tart has moved to koma-kt/koma, and the sample project is no longer available.

We previously used [google/iosched](https://github.com/google/iosched) as the sample project. Since it is archived, we will use its successor, [android/nowinandroid](https://github.com/android/nowinandroid), instead.

- #4